### PR TITLE
Indexing 03/06/2024

### DIFF
--- a/DroppingIndex.js
+++ b/DroppingIndex.js
@@ -1,0 +1,16 @@
+db.student.dropIndex({key: {student_id:551}},
+{
+			"createdCollectionAutomatically": false,
+			"numIdexesBefore":1,
+			"numIndexesAfter":2,
+			"ok":1
+})
+
+/* Output:
+{
+  ok: 0,
+  errmsg: "can't find index with key: { key: { student_id: 551 } }",
+  code: 27,
+  codeName: 'IndexNotFound'
+}
+*/

--- a/GeospatialIndexes.js
+++ b/GeospatialIndexes.js
@@ -1,0 +1,25 @@
+db.student.createIndex({"score":"2dsphere"},
+{
+			"createdCollectionAutomatically": false,
+			"numIdexesBefore":1,
+			"numIndexesAfter":2,
+			"ok":1
+})
+
+< score_2dsphere
+> db.student.getIndexes()
+
+/* Output:
+  [
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { class_id: 551 }, name: 'class_id_551' },
+  { v: 2, key: { student_id: 223344 }, name: 'student_id_223344' },
+  { v: 2, key: { student: 1 }, name: 'student_1' },
+  {
+    v: 2,
+    key: { score: '2dsphere' },
+    name: 'score_2dsphere',
+    '2dsphereIndexVersion': 3
+  }
+]
+  */

--- a/MultiKeyIndex.js
+++ b/MultiKeyIndex.js
@@ -1,0 +1,19 @@
+db.student.createIndex({student:1},
+{
+			"createdCollectionAutomatically": false,
+			"numIdexesBefore":1,
+			"numIndexesAfter":2,
+			"ok":1
+})
+
+< student_1
+> db.student.getIndexes()
+
+/* Output:
+  [
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { class_id: 551 }, name: 'class_id_551' },
+  { v: 2, key: { student_id: 223344 }, name: 'student_id_223344' },
+  { v: 2, key: { student: 1 }, name: 'student_1' }
+]
+  */

--- a/compoundIndex.js
+++ b/compoundIndex.js
@@ -1,0 +1,18 @@
+db.student.createIndex({student_id: 777777, student_id: 223344},
+{
+			"createdCollectionAutomatically": false,
+			"numIdexesBefore":1,
+			"numIndexesAfter":2,
+			"ok":1
+})
+
+< student_id_223344
+> db.student.getIndexes()
+
+/* Output:
+  [
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { class_id: 551 }, name: 'class_id_551' },
+  { v: 2, key: { student_id: 223344 }, name: 'student_id_223344' }
+]
+  */

--- a/singleFieldindex.js
+++ b/singleFieldindex.js
@@ -1,0 +1,19 @@
+db.student.createIndex({"class_id":551},
+{
+"createdCollectionAutomatically" :
+false,
+"numIndexesBefore": 1,
+"numIndexsAfter": 2,
+"ok" : 1
+})
+
+< class_id_551
+> db.student.getIndexes()
+
+/*
+Output:
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { class_id: 551 }, name: 'class_id_551' }
+]
+*/


### PR DESCRIPTION
**Indexing:** 
Indexing in MongoDB is a crucial aspect of database optimization, as it helps improve query performance by allowing the database engine to locate and retrieve documents more efficiently.
 Here are the basic steps to create and use indexes in MongoDB:
**1. Single Field Index:** A single field index in MongoDB is an index that is created on a single field within a document in a MongoDB collection.
![Screenshot (66)](https://github.com/rahulprasad2823/Database603D/assets/62901378/6a8d2b2e-c25a-4e1b-8d0b-b94e94cf743c)

**2. Compound Index :** A compound index in MongoDB is an index created on multiple fields within a document in a MongoDB collection. Unlike a single field index, which is created on a single field, a compound index involves multiple fields. This type of index can be beneficial when queries involve multiple criteria or when sorting and filtering are performed on multiple fields simultaneously.
Here's an example of creating a compound index in MongoDB:
![Screenshot (67)](https://github.com/rahulprasad2823/Database603D/assets/62901378/cfb804d3-cf80-46ee-bfbe-70844c3e5570)

**3.Multi-Key Index:**  A multi-key index in MongoDB is an index that is created on an array field, where each element of the array is indexed separately. This allows MongoDB to efficiently index and query documents based on the values within arrays. Multi-key indexes are particularly useful when dealing with fields that contain arrays of values.
Here's an example of creating a multi-key index in MongoDB:
![image](https://github.com/rahulprasad2823/Database603D/assets/62901378/dea9cfa2-2966-4b00-b92a-5722fc037dd9)

**4. Geospatial Indexes:** Geospatial indexes in MongoDB are specialized indexes that support efficient queries involving geographical data. MongoDB provides two types of geospatial indexes: 2d indexes and 2dsphere indexes. These indexes are designed to optimize the retrieval of documents based on their spatial coordinates, making it easier to perform location-based queries.
![Screenshot (70)](https://github.com/rahulprasad2823/Database603D/assets/62901378/6663bee0-d8e7-4fe6-b4e5-6e8804c0fa1f)

**5. Dropping an Index:** Dropping an index in MongoDB is a straightforward process. You can use the dropIndex() method to remove an existing index from a collection. 
Here's the basic syntax:
**db.collection.dropIndex("index_name")**
![Screenshot (71)](https://github.com/rahulprasad2823/Database603D/assets/62901378/ea346b21-0c67-4ae5-82db-e2974d5736e9)

